### PR TITLE
ensure that _foreColour and _backColour get set

### DIFF
--- a/Waterfall.glyphsPlugin/Contents/Resources/plugin.py
+++ b/Waterfall.glyphsPlugin/Contents/Resources/plugin.py
@@ -183,11 +183,11 @@ class WaterfallWindow(GeneralPlugin):
 			defaultBlack = NSColor.colorWithCalibratedRed_green_blue_alpha_(0,0,0,1)
 			self.w.foreColour = ColorWell((-spX*2-clX*2, spY, clX, edY), color=defaultBlack, callback=self.uiChange_)
 			self.w.backColour = ColorWell((-spX-clX, spY, clX, edY), color=defaultWhite, callback=self.uiChange_)
-			self._foreColour = defaultBlack
-			self._backColour = defaultWhite
 			self.w.refresh = Button((-spX-138, spY, 80, edY), "Refresh", callback=self.textChanged_)
 			self.w.instancePopup = PopUpButton((spX, spY*2+edY, -spX, edY), insList, callback=self.changeInstance_)
 			self.w.preview = TheView((0, spX*3+edY*2, -0, -0))
+			self.w.preview._foreColour = defaultBlack
+			self.w.preview._backColour = defaultWhite
 			self.w.preview.instances = {}
 			self.loadPrefs()
 			self.w.open()


### PR DESCRIPTION
I think this is what was intended in bcbdf3e. The other option
was to set them in `TheView.__init__`. But, I saw that changing
them to None in `__init__` was part of a bug fix back in 0c44f29.

Noticed `self.wrapper._backColour.set()` crashing first time
Waterfall was run without the defaults having been set, yet.